### PR TITLE
By default, ExecShell will add an io.Discard

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -501,6 +501,9 @@ type ExecShellOptions struct {
 	// If Interactive is true, then stdio from this exec is attached to the stdio
 	// of the running process.
 	Interactive bool
+
+	// If IgnoreResults is true, then no output will be watched and no exit code would emerge
+	IgnoreResults bool
 }
 
 // ExecShell executes a bash shell command inside a container. If the process
@@ -509,6 +512,11 @@ type ExecShellOptions struct {
 func ExecShell(ctx context.Context, client *docker.Client, containerID string, cmdString string, opts *ExecShellOptions) error {
 	if opts == nil {
 		opts = new(ExecShellOptions)
+	}
+
+	// If the caller expects a result, we need to at least attach an IO discarding type
+	if opts.CombinedOutput == nil && !opts.IgnoreResults {
+		opts.CombinedOutput = ioutil.Discard
 	}
 
 	execOpts := docker.CreateExecOptions{

--- a/containers_test.go
+++ b/containers_test.go
@@ -67,23 +67,17 @@ func TestExecExitError(t *testing.T) {
 
 	cmdStat := "stat /somewhere/strange/that/do/not/exist"
 	err = ExecShell(ctx, client, containerID, cmdStat, &ExecShellOptions{})
-	if err != nil {
-		if code, ok := IsExitError(err); !ok || code != 1 {
-			t.Errorf("error = %v; want exit code 1", err)
-		}
-	} else {
-		t.Error("Expecting an error, but none was returned")
+	if code, ok := IsExitError(err); !ok || code != 1 {
+		t.Logf("is it exit error? %v", ok)
+		t.Errorf("error = %v; want exit code 1, got %d", err, code)
 	}
 
 	// Should have the "-p" flag
 	cmdMkdir := "mkdir /somewhere/strange/that/do/not/exist"
 	err = ExecShell(ctx, client, containerID, cmdMkdir, &ExecShellOptions{})
-	if err != nil {
-		if code, ok := IsExitError(err); !ok || code != 1 {
-			t.Errorf("error = %v; want exit code 1", err)
-		}
-	} else {
-		t.Error("Expecting an error, but none was returned")
+	if code, ok := IsExitError(err); !ok || code != 1 {
+		t.Logf("is it exit error? %v", ok)
+		t.Errorf("error = %v; want exit code 1, got %d", err, code)
 	}
 
 }

--- a/containers_test.go
+++ b/containers_test.go
@@ -66,9 +66,7 @@ func TestExecExitError(t *testing.T) {
 	}
 
 	cmdStat := "stat /somewhere/strange/that/do/not/exist"
-	err = ExecShell(ctx, client, containerID, cmdStat, &ExecShellOptions{
-		CombinedOutput: os.Stdout,
-	})
+	err = ExecShell(ctx, client, containerID, cmdStat, &ExecShellOptions{})
 	if err != nil {
 		if code, ok := IsExitError(err); !ok || code != 1 {
 			t.Errorf("error = %v; want exit code 1", err)
@@ -79,9 +77,7 @@ func TestExecExitError(t *testing.T) {
 
 	// Should have the "-p" flag
 	cmdMkdir := "mkdir /somewhere/strange/that/do/not/exist"
-	err = ExecShell(ctx, client, containerID, cmdMkdir, &ExecShellOptions{
-		CombinedOutput: os.Stdout,
-	})
+	err = ExecShell(ctx, client, containerID, cmdMkdir, &ExecShellOptions{})
 	if err != nil {
 		if code, ok := IsExitError(err); !ok || code != 1 {
 			t.Errorf("error = %v; want exit code 1", err)


### PR DESCRIPTION
CombinedOutput will be `io.Discard` except when someone passed
IgnoreResults. Seems like a good way of throwing "async" command calls
that doesn't need to be checked after execution.
