### PR TITLE
Rework MkdirAll to not clobber permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .*.swp
-.vscode
+.vscode/settings.json

--- a/.vscode/copyright.code-snippets
+++ b/.vscode/copyright.code-snippets
@@ -1,0 +1,23 @@
+{
+	"Copyright": {
+		"prefix": "copyright",
+		"body": [
+			"$LINE_COMMENT Copyright $CURRENT_YEAR YourBase Inc.",
+			"$LINE_COMMENT",
+			"$LINE_COMMENT Licensed under the Apache License, Version 2.0 (the \"License\");",
+			"$LINE_COMMENT you may not use this file except in compliance with the License.",
+			"$LINE_COMMENT You may obtain a copy of the License at",
+			"$LINE_COMMENT",
+			"$LINE_COMMENT     https://www.apache.org/licenses/LICENSE-2.0",
+			"$LINE_COMMENT",
+			"$LINE_COMMENT Unless required by applicable law or agreed to in writing, software",
+			"$LINE_COMMENT distributed under the License is distributed on an \"AS IS\" BASIS,",
+			"$LINE_COMMENT WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
+			"$LINE_COMMENT See the License for the specific language governing permissions and",
+			"$LINE_COMMENT limitations under the License.",
+			"$LINE_COMMENT",
+			"$LINE_COMMENT SPDX-License-Identifier: Apache-2.0"
+		],
+		"description": "Apache license header"
+	}
+}

--- a/containers.go
+++ b/containers.go
@@ -405,7 +405,6 @@ func Upload(ctx context.Context, client *docker.Client, containerID string, remo
 	}
 	realHeader := new(tar.Header)
 	*realHeader = *header
-	// Trim leading slashes.
 	var dir string
 	dir, realHeader.Name = slashpath.Split(remotePath)
 

--- a/containers.go
+++ b/containers.go
@@ -3,7 +3,6 @@ package narwhal
 
 import (
 	"archive/tar"
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -404,6 +403,16 @@ func Upload(ctx context.Context, client *docker.Client, containerID string, remo
 	if !slashpath.IsAbs(remotePath) {
 		return fmt.Errorf("upload file to container: path %q is not absolute", remotePath)
 	}
+	realHeader := new(tar.Header)
+	*realHeader = *header
+	// Trim leading slashes.
+	var dir string
+	dir, realHeader.Name = slashpath.Split(remotePath)
+
+	if err := MkdirAll(ctx, client, containerID, dir, nil); err != nil {
+		return fmt.Errorf("upload file to container: %w", err)
+	}
+
 	tmpFile, err := ioutil.TempFile("", "yb*.tar")
 	if err != nil {
 		return fmt.Errorf("upload file to container: %w", err)
@@ -414,10 +423,6 @@ func Upload(ctx context.Context, client *docker.Client, containerID string, remo
 		os.Remove(name)
 	}()
 
-	realHeader := new(tar.Header)
-	*realHeader = *header
-	// Trim leading slashes.
-	realHeader.Name = strings.TrimLeft(slashpath.Clean(remotePath), "/")
 	if err := archiveFile(tmpFile, content, realHeader); err != nil {
 		return fmt.Errorf("upload file to container: %w", err)
 	}
@@ -427,7 +432,7 @@ func Upload(ctx context.Context, client *docker.Client, containerID string, remo
 	}
 	err = client.UploadToContainer(containerID, docker.UploadToContainerOptions{
 		InputStream:          tmpFile,
-		Path:                 "/",
+		Path:                 dir,
 		NoOverwriteDirNonDir: true,
 	})
 	if err != nil {
@@ -459,43 +464,6 @@ func archiveFile(tf io.Writer, source io.Reader, header *tar.Header) error {
 	}
 	if err := w.Close(); err != nil {
 		return err
-	}
-	return nil
-}
-
-// MkdirAll ensures that the given directory and all its parents directories
-// exist. As root
-func MkdirAll(ctx context.Context, client *docker.Client, containerID string, path string) error {
-	return MkdirAllOwnedBy(ctx, client, containerID, path, "", "")
-}
-
-// MkdirAllOwnedBy ensures that the given directory and all its parents directories
-// exist. As an user defined by uid and gid
-func MkdirAllOwnedBy(ctx context.Context, client *docker.Client, containerID string, path string, uid string, gid string) error {
-	opts := docker.CreateExecOptions{
-		Context:      ctx,
-		Cmd:          []string{"mkdir", "-p", path},
-		AttachStdout: true,
-		AttachStderr: true,
-		Container:    containerID,
-	}
-	if uid != "" || gid != "" {
-		opts.User = uid + ":" + gid
-	}
-	exec, err := client.CreateExec(opts)
-	if err != nil {
-		return fmt.Errorf("mkdir %q in container %q: %w", path, containerID, err)
-	}
-	out := new(bytes.Buffer)
-	err = client.StartExec(exec.ID, docker.StartExecOptions{
-		OutputStream: out,
-		ErrorStream:  out,
-	})
-	if err != nil {
-		if out.Len() > 0 {
-			return fmt.Errorf("mkdir %q in container %q: %w\n%s", path, containerID, err, out)
-		}
-		return fmt.Errorf("mkdir %q in container %q: %w", path, containerID, err)
 	}
 	return nil
 }

--- a/mkdir.go
+++ b/mkdir.go
@@ -1,0 +1,155 @@
+// Copyright 2020 YourBase Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package narwhal
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	slashpath "path"
+	"strings"
+
+	docker "github.com/fsouza/go-dockerclient"
+)
+
+// MkdirOptions specifies optional parameters to MkdirAll.
+type MkdirOptions struct {
+	// Perm specifies the permission bits for any created directories.
+	// If zero, then 0755 is used. If you really want to force no permissions,
+	// then use os.ModeDir.
+	Perm os.FileMode
+	// UID specifies the owner of any created directories.
+	// Defaults to root.
+	UID int
+	// GID specifies the group of any created directories.
+	// Defaults to root.
+	GID int
+}
+
+// MkdirAll ensures that the given directory and all its parents directories
+// exist. The container does not have to be running.
+func MkdirAll(ctx context.Context, client *docker.Client, containerID string, path string, opts *MkdirOptions) error {
+	cleanedPath := slashpath.Clean(path)
+	if !slashpath.IsAbs(cleanedPath) {
+		return fmt.Errorf("mkdir -p %s: not an absolute path", path)
+	}
+	cleanedPath = strings.TrimPrefix(cleanedPath, "/")
+	if cleanedPath == "" {
+		return nil
+	}
+	parts := strings.Split(cleanedPath, "/")
+
+	// Find deepest directory that exists. Searching in reverse because stat will
+	// download a whole directory tree.
+	start := len(parts)
+	for ; start > 0; start-- {
+		elem := "/" + strings.Join(parts[:start], "/")
+		hdr, err := stat(ctx, client, containerID, elem)
+		if err == nil {
+			if hdr.Typeflag != tar.TypeDir {
+				return fmt.Errorf("mkdir -p %s: %s is not a directory", path, elem)
+			}
+			break
+		}
+		var dockerErr *docker.Error
+		if !(errors.As(err, &dockerErr) && dockerErr.Status == http.StatusNotFound) {
+			return fmt.Errorf("mkdir -p %s: %w", path, err)
+		}
+	}
+
+	// Now start creating directories.
+	dir := "/" + strings.Join(parts[:start], "/")
+	err := client.UploadToContainer(containerID, docker.UploadToContainerOptions{
+		Context:              ctx,
+		NoOverwriteDirNonDir: true,
+		Path:                 dir,
+		InputStream:          bytes.NewReader(directoryTar(parts[start:], opts)),
+	})
+	if err != nil {
+		return fmt.Errorf("mkdir -p %s: %w", path, err)
+	}
+	return nil
+}
+
+func stat(ctx context.Context, client *docker.Client, containerID string, path string) (*tar.Header, error) {
+	// TODO(light): There is a more direct operation to stat
+	// (https://docs.docker.com/engine/api/v1.40/#operation/ContainerArchiveInfo),
+	// but the Docker client does not expose the operation nor the URL endpoint
+	// to implement ourselves.
+	pr, pw := io.Pipe()
+	type headerResult struct {
+		hdr *tar.Header
+		err error
+	}
+	headerChan := make(chan headerResult, 1)
+	go func() {
+		defer pr.Close()
+		tr := tar.NewReader(pr)
+		hdr, err := tr.Next()
+		headerChan <- headerResult{hdr, err}
+	}()
+	downloadErr := client.DownloadFromContainer(containerID, docker.DownloadFromContainerOptions{
+		Context:      ctx,
+		Path:         path,
+		OutputStream: pw,
+	})
+	pw.Close()
+	readResult := <-headerChan
+	// Errors from DownloadFromContainer are largely expected because we rudely
+	// close the stream to avoid wasting resources. However, if we weren't able
+	// to read the first tar entry, then something is probably amiss.
+	if readResult.err != nil {
+		if downloadErr != nil {
+			return nil, fmt.Errorf("stat %s: %w", path, downloadErr)
+		}
+		return nil, fmt.Errorf("stat %s: %w", path, readResult.err)
+	}
+	return readResult.hdr, nil
+}
+
+func directoryTar(parts []string, opts *MkdirOptions) []byte {
+	buf := new(bytes.Buffer)
+	tw := tar.NewWriter(buf)
+	hdr := &tar.Header{
+		Typeflag: tar.TypeDir,
+	}
+	if opts != nil {
+		hdr.Uid = opts.UID
+		hdr.Gid = opts.GID
+		const dirFlag = 040000
+		if opts.Perm == 0 {
+			hdr.Mode = 0755 | dirFlag
+		} else {
+			hdr.Mode = int64(opts.Perm&os.ModePerm) | dirFlag
+		}
+	}
+	for i := range parts {
+		hdr.Name = strings.Join(parts[:i+1], "/") + "/"
+		if err := tw.WriteHeader(hdr); err != nil {
+			panic(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		panic(err)
+	}
+	return buf.Bytes()
+}

--- a/mkdir_test.go
+++ b/mkdir_test.go
@@ -1,0 +1,204 @@
+// Copyright 2020 YourBase Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package narwhal
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	docker "github.com/fsouza/go-dockerclient"
+	"zombiezen.com/go/log/testlog"
+)
+
+func TestMkdirAll(t *testing.T) {
+	ctx := testlog.WithTB(context.Background(), t)
+	client := DockerClient()
+	err := PullImageIfNotHere(ctx, client, &testLogWriter{logger: t}, &ContainerDefinition{
+		Image: "hello-world",
+	}, docker.AuthConfiguration{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	container, err := client.CreateContainer(docker.CreateContainerOptions{
+		Config: &docker.Config{
+			Image: "hello-world",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err := client.RemoveContainer(docker.RemoveContainerOptions{
+			ID: container.ID,
+		})
+		if err != nil {
+			t.Logf("removing container %s: %v", container.ID, err)
+		}
+	}()
+
+	t.Run("DoesNotExist", func(t *testing.T) {
+		const (
+			path     = "/foo/bar"
+			wantMode = 040751
+			wantUID  = 1001
+			wantGID  = 1002
+		)
+		err = MkdirAll(ctx, client, container.ID, path, &MkdirOptions{
+			Perm: wantMode & os.ModePerm,
+			UID:  wantUID,
+			GID:  wantGID,
+		})
+		if err != nil {
+			t.Error("MkdirAll:", err)
+		}
+		buf := new(bytes.Buffer)
+		err = client.DownloadFromContainer(container.ID, docker.DownloadFromContainerOptions{
+			Path:         "/foo",
+			OutputStream: buf,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		tarReader := tar.NewReader(buf)
+		foundFoo := false
+		foundBar := false
+		for {
+			header, err := tarReader.Next()
+			if err != nil {
+				if !errors.Is(err, io.EOF) {
+					t.Error(err)
+				}
+				break
+			}
+			t.Logf("Found %q", header.Name)
+			switch header.Name {
+			case "foo/":
+				foundFoo = true
+			case "foo/bar/":
+				foundBar = true
+			default:
+				continue
+			}
+			if header.Typeflag != tar.TypeDir {
+				t.Errorf("%s type = %q; want %q", path, header.Typeflag, tar.TypeDir)
+			}
+			if header.Mode != wantMode {
+				t.Errorf("%s mode = %#o; want %#o", path, header.Mode, wantMode)
+			}
+			if header.Uid != wantUID {
+				t.Errorf("%s UID = %d; want %d", path, header.Uid, wantUID)
+			}
+			if header.Gid != wantGID {
+				t.Errorf("%s GID = %d; want %d", path, header.Gid, wantGID)
+			}
+		}
+		if !foundFoo || !foundBar {
+			t.Errorf("%s not found", path)
+		}
+	})
+
+	t.Run("ExistingDir", func(t *testing.T) {
+		const (
+			path     = "/etc"
+			wantMode = 040755
+		)
+		err = MkdirAll(ctx, client, container.ID, path, &MkdirOptions{
+			Perm: 0777, // intentionally set a different permission
+		})
+		if err != nil {
+			t.Error("MkdirAll:", err)
+		}
+		buf := new(bytes.Buffer)
+		err = client.DownloadFromContainer(container.ID, docker.DownloadFromContainerOptions{
+			Path:         path,
+			OutputStream: buf,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		tarReader := tar.NewReader(buf)
+		found := false
+		for {
+			header, err := tarReader.Next()
+			if err != nil {
+				if !errors.Is(err, io.EOF) {
+					t.Error(err)
+				}
+				break
+			}
+			t.Logf("Found %q", header.Name)
+			if header.Name != "etc/" {
+				continue
+			}
+			found = true
+			if header.Typeflag != tar.TypeDir {
+				t.Errorf("%s type = %q; want %q", path, header.Typeflag, tar.TypeDir)
+			}
+			if header.Mode != wantMode {
+				t.Errorf("%s mode = %#o; want %#o", path, header.Mode, wantMode)
+			}
+		}
+		if !found {
+			t.Errorf("%s not found", path)
+		}
+	})
+
+	t.Run("ExistingFile", func(t *testing.T) {
+		const path = "/etc/hostname"
+		err = MkdirAll(ctx, client, container.ID, path, nil)
+		if err == nil {
+			t.Error("MkdirAll did not return an error")
+		} else {
+			t.Log("MkdirAll:", err)
+		}
+		buf := new(bytes.Buffer)
+		err = client.DownloadFromContainer(container.ID, docker.DownloadFromContainerOptions{
+			Path:         "etc/",
+			OutputStream: buf,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		tarReader := tar.NewReader(buf)
+		found := false
+		for {
+			header, err := tarReader.Next()
+			if err != nil {
+				if !errors.Is(err, io.EOF) {
+					t.Error(err)
+				}
+				break
+			}
+			t.Logf("Found %q", header.Name)
+			if header.Name != "etc/hostname" {
+				continue
+			}
+			found = true
+			if header.Typeflag != tar.TypeReg {
+				t.Errorf("%s type = %q; want %q", path, header.Typeflag, tar.TypeReg)
+			}
+		}
+		if !found {
+			t.Errorf("%s not found", path)
+		}
+	})
+}


### PR DESCRIPTION
Also no longer requires the container to be running, so now using it in `Upload` and `UploadFile`.

Fixes ch-2868