### PR TITLE
Don't panic on bad port format

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -605,6 +605,9 @@ func CreateContainer(ctx context.Context, client *docker.Client, pullOutput io.W
 
 		for _, portSpec := range containerDef.Ports {
 			parts := strings.Split(portSpec, ":")
+			if len(parts) != 2 {
+				return "", fmt.Errorf("create container %s: format of port must be HOSTPORT:CONTAINERPORT, but was %s", containerName, portSpec)
+			}
 			externalPort := parts[0]
 			internalPort := parts[1]
 


### PR DESCRIPTION
When passing a .yourbase.yml like:
```yaml
dependencies:
  runtime:
    - node:15.2.1
exec:
  commands:
    - npm install http-server
    - http-server
  container:
    ports:
      - 8080 # notice the bad format
```
, `yb` panics with
```
INFO Creating Docker network 421a25d4a7b43302...
INFO Not using cache for https://github.com/krallin/tini/releases/download/v0.19.0/tini-amd64
INFO Downloading https://github.com/krallin/tini/releases/download/v0.19.0/tini-amd64
INFO Creating yourbase/yb_ubuntu:18.04 container...
INFO Will map the following ports:
INFO Removing Docker network 421a25d4a7b43302...
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
github.com/yourbase/narwhal.CreateContainer(0x556310e340c0, 0xc0002ae930, 0xc0003a03f0, 0x556310e221c0, 0xc000010020, 0xc00011e300, 0x18, 0xc000707548, 0x1, 0x1)
        github.com/yourbase/narwhal@v0.6.3/containers.go:609 +0x17c8
github.com/yourbase/yb/internal/biome.CreateContainer(0x556310e34040, 0xc000034098, 0xc0003a03f0, 0xc0007077e8, 0x0, 0x0, 0x0)
        github.com/yourbase/yb/internal/biome/docker.go:126 +0x3a8
main.newBiome(0x556310e34040, 0xc000034098, 0xc000269dc0, 0xd, 0x556310939820, 0x7, 0xc0002ff2c0, 0xc0003b8b10, 0x0, 0x0, ...)
        github.com/yourbase/yb/cmd/yb/helpers.go:92 +0x777
main.(*execCmd).run(0xc0003960c0, 0x556310e34040, 0xc000034098, 0x0, 0x0)
        github.com/yourbase/yb/cmd/yb/exec.go:82 +0x405
main.newExecCmd.func1(0xc00038f340, 0x5563113183a0, 0x0, 0x0, 0x0, 0x0)
        github.com/yourbase/yb/cmd/yb/exec.go:32 +0x49
github.com/spf13/cobra.(*Command).execute(0xc00038f340, 0x5563113183a0, 0x0, 0x0, 0xc00038f340, 0x5563113183a0)
        github.com/spf13/cobra@v1.1.1/command.go:850 +0x47c
github.com/spf13/cobra.(*Command).ExecuteC(0xc00038e2c0, 0xc00025ff20, 0x1, 0x1)
        github.com/spf13/cobra@v1.1.1/command.go:958 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.1.1/command.go:895
github.com/spf13/cobra.(*Command).ExecuteContext(...)
        github.com/spf13/cobra@v1.1.1/command.go:888
main.main()
        github.com/yourbase/yb/cmd/yb/main.go:86 +0x44f
```
This branch changes the panic to a user-friendly error message.