### PR TITLE
Eliminate parsing of volume-like mounts and use docker.HostMount directly

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"os"
 	slashpath "path"
-	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"

--- a/containers.go
+++ b/containers.go
@@ -69,13 +69,12 @@ type ContainerDefinition struct {
 	// made available at the returned Container.HealthCheckAddr address.
 	HealthCheckPort int
 
-	Mounts       []docker.HostMount
-	Environment  []string
-	WorkDir      string
-	Privileged   bool
-	ExecUserID   string
-	ExecGroupID  string
-	LocalWorkDir string
+	Mounts      []docker.HostMount
+	Environment []string
+	WorkDir     string
+	Privileged  bool
+	ExecUserID  string
+	ExecGroupID string
 }
 
 func (c *ContainerDefinition) ImageNameWithTag() string {


### PR DESCRIPTION
Updates ch-466